### PR TITLE
Fix Typo in Memcached Crash Data Accessibility Note

### DIFF
--- a/hoodi/db/install-memcached.sh
+++ b/hoodi/db/install-memcached.sh
@@ -17,5 +17,5 @@ helm install memcached -n mcd --create-namespace -f memcached-values.yml bitnami
 # Note:
 # Without using mcrouter, data is not replicated between nodes
 # Applications must connect to *all* nodes to get all data
-# In case of a crash, data is inaccesible until the node is restarted
+# In case of a crash, data is inaccessible until the node is restarted
 # However, this still provides redundancy in that we're less likely to lost memcached altogether

--- a/mainnet/db/install-memcached.sh
+++ b/mainnet/db/install-memcached.sh
@@ -17,5 +17,5 @@ helm install memcached -n mcd --create-namespace -f memcached-values.yml bitnami
 # Note:
 # Without using mcrouter, data is not replicated between nodes
 # Applications must connect to *all* nodes to get all data
-# In case of a crash, data is inaccesible until the node is restarted
+# In case of a crash, data is inaccessible until the node is restarted
 # However, this still provides redundancy in that we're less likely to lost memcached altogether


### PR DESCRIPTION


Description:  
This pull request corrects a typo in the memcached installation scripts for both `hoodi/db/install-memcached.sh` and `mainnet/db/install-memcached.sh`. The word "inaccessible" replaces the incorrect "inaccesible" in the note regarding data availability after a crash. No functional changes were made; this update is documentation-only to improve clarity and accuracy.
